### PR TITLE
Adding magic/file dep to sync with https://github.com/dgtlmoon/changedetection.io/blob/master/Dockerfile (Required for some favicon handling)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN \
     zip \
     zlib-dev && \
   apk add --update --no-cache \
+    file \
     libjpeg \
     libxslt \
     nodejs \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -24,6 +24,7 @@ RUN \
     zip \
     zlib-dev && \
   apk add --update --no-cache \
+    file \
     libjpeg \
     libxslt \
     nodejs \


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

This is related to https://github.com/dgtlmoon/changedetection.io/issues/3343 in that the deps for Dockerfile are out of sync, it needs `file` (mainly the sub-package `magic`) to handle the favicon types


Should be tested on our end here https://github.com/dgtlmoon/changedetection.io/actions/runs/16590275175/job/46923985976